### PR TITLE
Factorice GUI management and include 2 new gui's

### DIFF
--- a/src/main/java/cr/fran/gui/GUIArgs.java
+++ b/src/main/java/cr/fran/gui/GUIArgs.java
@@ -1,0 +1,49 @@
+package cr.fran.gui;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.security.KeyStore.PasswordProtection;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GUIArgs implements GUIInterface {
+	private String documenttosign;
+	private String documenttosave;
+	private static PasswordProtection pin;
+
+	public void setArgs(String[] args) {
+		List<String> arguments = new ArrayList<String>();
+		for (String params : args) {
+			if(!params.startsWith("-")) {
+				arguments.add(params);
+			}
+		}
+		documenttosign = Paths.get(arguments.get(0)).toAbsolutePath().toString();
+		documenttosave = Paths.get(arguments.get(1)).toAbsolutePath().toString();
+		
+	}
+
+	public String getDocumentToSign() {
+		return documenttosign;
+	}
+
+	public String getPathToSave() {
+		return documenttosave;
+	}
+
+	public PasswordProtection getPin() {
+		String pintext = null;
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		try {
+			pintext = br.readLine();
+		} catch (IOException e) {
+			System.err.println("PIN not Found");
+			System.exit(1);
+		}
+		pin = new PasswordProtection(pintext.toCharArray());
+		return pin;
+	}
+
+}

--- a/src/main/java/cr/fran/gui/GUIAwt.java
+++ b/src/main/java/cr/fran/gui/GUIAwt.java
@@ -1,0 +1,123 @@
+package cr.fran.gui;
+
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.awt.TextField;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.nio.file.Paths;
+import java.security.KeyStore.PasswordProtection;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GUIAwt implements GUIInterface{
+
+    private static Dialog pinDialog;
+    private static FileDialog loadDialog;
+    private static PasswordProtection pin;
+	private String documenttosign=null;
+	private String documenttosave=null;
+	
+	public String getDocumentToSign() {
+		if(documenttosign != null){
+			return documenttosign;
+		}
+		String fileName = null;
+        loadDialog = new FileDialog(loadDialog,
+                "Seleccionar documento a firmar");
+            loadDialog.setFilenameFilter(new FilenameFilter() {
+                public boolean accept(File dir, String name) {
+                    return name.endsWith(".pdf") || name.endsWith(".PDF");
+                }
+            });
+        loadDialog.setFile("*.pdf");
+        loadDialog.setLocationRelativeTo(null);
+        loadDialog.setVisible(true);
+        loadDialog.dispose();
+        if (loadDialog.getFile() == null) {
+            System.out.println("Sintaxis: firmador.jar fichero.pdf");
+            System.exit(1);
+        } else {
+            fileName = loadDialog.getDirectory() + loadDialog.getFile();
+        }
+        return fileName;
+	}
+
+	public String getPathToSave() {
+		if(documenttosave!= null){
+			return documenttosave;
+		}
+		
+		String fileName = null;
+        FileDialog saveDialog = null;
+        saveDialog = new FileDialog(saveDialog,
+            "Guardar documento", FileDialog.SAVE);
+        String saveDirectory = null;
+        String saveFileName = null;
+
+        saveDirectory = loadDialog.getDirectory();
+        saveFileName = loadDialog.getFile();
+
+        saveDialog.setDirectory(saveDirectory);
+        saveDialog.setFile(saveFileName.substring(0,
+            saveFileName.lastIndexOf(".")) + "-firmado.pdf");
+        saveDialog.setFilenameFilter(loadDialog.getFilenameFilter());
+        saveDialog.setLocationRelativeTo(null);
+        saveDialog.setVisible(true);
+        saveDialog.dispose();
+        if (saveDialog.getFile() == null) {
+            System.exit(1);
+        } else {
+            fileName = saveDialog.getDirectory() + saveDialog.getFile();
+        }
+        return fileName;
+	}
+
+	public PasswordProtection getPin() {
+        pinDialog = new Dialog(pinDialog, "Ingresar PIN", true);
+        pinDialog.setLocationRelativeTo(null);
+        final TextField pinField = new TextField(17);
+        pinField.setEchoChar('●');
+        pinField.addKeyListener(new KeyAdapter() {
+            public void keyPressed(KeyEvent e) {
+                switch (e.getKeyCode()) {
+                    case KeyEvent.VK_ENTER:
+                        pin = new PasswordProtection(pinField.getText().toCharArray());
+                        pinDialog.dispose();
+                        break;
+                    case KeyEvent.VK_ESCAPE:
+                        System.exit(1);
+                }
+            }
+        });
+        pinDialog.addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent windowEvent) {
+                System.exit(1);
+            }
+        });
+        pinDialog.add(pinField);
+        pinDialog.pack();
+        pinDialog.setVisible(true);
+        return pin;
+	}
+
+	public void setArgs(String[] args) {
+		List<String> arguments = new ArrayList<String>();
+		for (String params : args) {
+			if(!params.startsWith("-")) {
+				arguments.add(params);
+			}
+		}
+		if(arguments.size()>1)
+			documenttosign = Paths.get(arguments.get(0)).toAbsolutePath().toString();
+		
+		if(arguments.size()>2)
+		documenttosave = Paths.get(arguments.get(1)).toAbsolutePath().toString();
+		
+	}
+
+}

--- a/src/main/java/cr/fran/gui/GUIInterface.java
+++ b/src/main/java/cr/fran/gui/GUIInterface.java
@@ -1,0 +1,12 @@
+package cr.fran.gui;
+
+import java.security.KeyStore.PasswordProtection;
+
+public interface GUIInterface {
+
+	void setArgs(String[] args);
+	String getDocumentToSign();
+	String getPathToSave();
+	PasswordProtection getPin();
+	
+}

--- a/src/main/java/cr/fran/gui/GUISelector.java
+++ b/src/main/java/cr/fran/gui/GUISelector.java
@@ -1,0 +1,33 @@
+package cr.fran.gui;
+
+public class GUISelector {
+	
+	public String getGUIClassName(String[] args){
+		String dev = "awt";
+		
+		for (String params : args) {
+			if(params.startsWith("-d")) {
+				dev = params.substring(2);
+			}
+		}
+		return dev;
+	}
+
+	public GUIInterface getInterface(String[] args){
+		String name = this.getGUIClassName(args);
+		return this.getInterface(name);
+	}
+	public GUIInterface getInterface(String name){
+		GUIInterface gui=null;
+		
+		if(name.equals("args")){
+			gui=new GUIArgs();
+			
+		}else if(name.equals("shell")){
+			gui=new GUIShell();
+		}else{
+			gui=new GUIAwt();
+		}
+	  return gui;
+	}
+}

--- a/src/main/java/cr/fran/gui/GUIShell.java
+++ b/src/main/java/cr/fran/gui/GUIShell.java
@@ -1,0 +1,71 @@
+package cr.fran.gui;
+
+import java.io.BufferedReader;
+import java.io.Console;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.security.KeyStore.PasswordProtection;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GUIShell implements GUIInterface{
+    private static PasswordProtection pin;
+	private String documenttosign=null;
+	private String documenttosave=null;
+
+	public void setArgs(String[] args) {
+		List<String> arguments = new ArrayList<String>();
+		for (String params : args) {
+			if(!params.startsWith("-")) {
+				arguments.add(params);
+			}
+		}
+		if(arguments.size()>1)
+			documenttosign = Paths.get(arguments.get(0)).toAbsolutePath().toString();
+		
+		if(arguments.size()>2)
+		documenttosave = Paths.get(arguments.get(1)).toAbsolutePath().toString();
+		
+	}
+	
+	private String readFromInput(String message){
+		System.out.println(message);
+		String plaintext = null;
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		try {
+			plaintext = br.readLine();
+	
+		} catch (IOException e) {
+			System.err.println("I can't read in stdin");
+			System.exit(1);
+		}
+		return plaintext;
+	}
+
+	public String getDocumentToSign() {
+		String docpath=readFromInput("Path del documento a firmar: ");
+		return Paths.get(docpath).toAbsolutePath().toString();
+	}
+
+	public String getPathToSave() {
+		String docpath=readFromInput("Path del documento a guardar: ");
+		return Paths.get(docpath).toAbsolutePath().toString();
+	}
+
+	public PasswordProtection getPin() {
+		Console console = System.console(); 
+		char[] password = null;
+		if(console != null) {
+			password = console.readPassword("PIN: ");
+		}else{
+			System.err.println("System console not present, maybe you are running on IDE, got fallback");
+			String docpath=readFromInput("PIN: ");
+			password = docpath.toCharArray();
+
+		}
+		pin = new PasswordProtection(password);
+		return pin;
+	}
+
+}


### PR DESCRIPTION
Allow new ways to sign pdf documents,
- Awt GUI  (Just adjust a little bit the code)
- Args GUI (For programs who want to use via pipes)
- Shell GUI (For use in shell)

Also change some behavior of parameters:
- Include -dargs , -dshell, -dawt to choose the gui method.
- in Awt  allow to pass sign path and save document path.

Also simplify main method removing a lot of GUI code. 